### PR TITLE
add functionning calendar

### DIFF
--- a/addevent.js
+++ b/addevent.js
@@ -48,7 +48,6 @@ function saveTime() {
     const timeArray = Array.from(eventSection.querySelectorAll('.eventTime')).map(input => {
     return input.value;
     });
-    console.log("Saving time array:", timeArray);
     localStorage.setItem('time', JSON.stringify(timeArray));
 }
 

--- a/calendarDates.js
+++ b/calendarDates.js
@@ -1,11 +1,60 @@
-const calendarDisplay = document.querySelector(".calendarDisplay");
-let previousSelectedCell = null;
+const currentTime = "https://time.now/developer/api/timezone/Europe/Chisinau";
 
-for (let i = 1; i <= 31; i++) {
-    const dateCell = document.createElement("div");
-    dateCell.className = "calendarDate";
-    dateCell.innerHTML = `<p>${i}</p>`;
-    calendarDisplay.appendChild(dateCell);
+const headerSection = document.querySelector("#headerText");
+const calendarDisplay = document.querySelector(".calendarDisplay");
+const dayDisplay = document.querySelector(".dayDisplay");
+const icon = document.querySelector(".calendar-icon");
+const input = document.querySelector("#monthInput");
+let previousSelectedCell = null;
+let previousSelectedDay = null;
+let currentYear, currentMonth;
+let selectedDate = null;
+
+const months = ["January", "February","March","April","May","June","July","August","September","October","November","December"]
+
+input.addEventListener("input", () => {
+    let value = input.value;
+    let year = parseInt(value.substr(0, 4));
+    let monthIndex = parseInt(value.substr(5, 2)) - 1;
+    currentYear = year;
+    currentMonth = monthIndex;
+    previousSelectedDay = null;
+    previousSelectedCell = null;
+    selectedDate = null;
+    generateCalendar(year, monthIndex);
+});
+
+function updateSelectedDate() {
+    if (previousSelectedDay !== null && currentYear !== undefined && currentMonth !== undefined) {
+        const month = String(currentMonth + 1).padStart(2, '0');
+        const day = String(previousSelectedDay).padStart(2, '0');
+        selectedDate = `${currentYear}-${month}-${day}`;
+        dayDisplay.innerHTML = `Plans for  ${months[currentMonth]} ${previousSelectedDay}, ${currentYear}`;
+        
+    } else {
+        selectedDate = null;
+    }
+}
+
+function generateCalendar(year, month) {
+    calendarDisplay.innerHTML = '';
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    for (let i = 1; i <= daysInMonth; i++) {
+        const dateCell = document.createElement("div");
+        dateCell.className = "calendarDate";
+        dateCell.innerHTML = `<p>${i}</p>`;
+        calendarDisplay.appendChild(dateCell);
+    }
+    if (previousSelectedDay <= daysInMonth) {
+        const cells = calendarDisplay.querySelectorAll('.calendarDate');
+        for (let cell of cells) {
+            if (parseInt(cell.querySelector('p').innerHTML) === previousSelectedDay) {
+                cell.id = 'calendarDateselected';
+                previousSelectedCell = cell;
+                break;
+            }
+        }
+    }
 }
 
 calendarDisplay.addEventListener("click", (event) => {
@@ -17,6 +66,8 @@ calendarDisplay.addEventListener("click", (event) => {
     if (previousSelectedCell === clickedCell) {
         clickedCell.removeAttribute("id");
         previousSelectedCell = null;
+        previousSelectedDay = null;
+        selectedDate = null;
         return;
     }
 
@@ -26,11 +77,42 @@ calendarDisplay.addEventListener("click", (event) => {
 
     clickedCell.id = "calendarDateselected";
     previousSelectedCell = clickedCell;
+    previousSelectedDay = parseInt(clickedCell.querySelector('p').innerHTML);
+    updateSelectedDate();
 });
 
 document.addEventListener("click", (event) => {
     if (previousSelectedCell && !event.target.closest(".calendarDate")) {
         previousSelectedCell.removeAttribute("id");
         previousSelectedCell = null;
+        previousSelectedDay = null;
+        selectedDate = null;
     }
 });
+
+fetch(currentTime)
+    .then(res => res.json())
+    .then(data => {
+    let time = data.datetime;
+    
+    let year = parseInt(time.substr(0, 4));
+    let monthIndex = parseInt(time.substr(5, 2)) - 1;
+    currentYear = year;
+    currentMonth = monthIndex;
+    input.value = time.substr(0, 7);
+    generateCalendar(year, monthIndex);
+
+    let currentDay = parseInt(time.substr(8, 2));
+    headerSection.innerHTML = `Today is  ${months[currentMonth]} ${currentDay}, ${currentYear}`;
+    previousSelectedDay = currentDay;
+    const cells = calendarDisplay.querySelectorAll('.calendarDate');
+    for (let cell of cells) {
+        if (parseInt(cell.querySelector('p').innerHTML) === currentDay) {
+            cell.id = 'calendarDateselected';
+            previousSelectedCell = cell;
+            break;
+        }
+    }
+    updateSelectedDate();
+});
+

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -1,11 +1,38 @@
-.monthDisplay{
+#headerText{
+    font-family: "Questrial", sans-serif;
+    font-size: 1.5em;
+}
+
+.month-picker-wrapper{
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    margin-bottom: 15px;
+}
+
+#monthInput::-webkit-calendar-picker-indicator{
+    cursor: pointer;
+    width: 30px;
+    height: 30px;
+}
+
+#monthInput{
     display: flex;
     flex-direction: column;
-    background-color: #A6CDC6;
-    text-align: center;
-    font-size: 30px;
+    align-items: center;
+    justify-content: center;
 
+    font-family: "Questrial", sans-serif;
+    font-size: 1.3em;
+
+    background-color: #A6CDC6;
+    padding: 20px;
     border-radius: 5px;
+    width: max-content;
+    width: 100%;
 }
 
 .calendarDisplay{
@@ -36,8 +63,8 @@
 
 .calendarDate:hover{
     cursor: pointer;
-    background-color: #63978d;
-    color: #ddfff9;
+    background-color: #90ddce;
+    color: #000000;
 }
 
 #calendarDateselected{

--- a/css/desktopLayout.css
+++ b/css/desktopLayout.css
@@ -14,7 +14,7 @@ body{
 
     display: flex;
     align-items: center;
-
+    justify-content: center;
    
     height: 50px;
     width: 100%;

--- a/css/mobileLayout.css
+++ b/css/mobileLayout.css
@@ -10,6 +10,9 @@ body{
 #headerSection{
     grid-row: 1 / 2;
     padding: 10px;
+
+    display: flex;
+    justify-content: center;
 }
 
 .weatherSection{
@@ -56,6 +59,7 @@ body{
 }
 
 .dayDisplay{
+    margin-top: 25px;
     justify-self: center;
 }
 

--- a/css/weather.css
+++ b/css/weather.css
@@ -63,15 +63,18 @@
 
     font-size: 2em;
     color: #FBF5DD;
+    z-index: 1;
 }
 
 #weatherIcon{
     margin-right: 3%;
     border-radius: 5px;
 
-    width: 160px;
-    height: 160px;
-    
+    width: 150px;
+    height: 150px;
+
+    position: relative;
+    z-index: 0;
 }
 
 }

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <body>
 
 <div id="headerSection">
-    <a>00:00, current-date-here</a>
+    <p id="headerText"></p>
 </div>
 
 <div class="weatherSection">
@@ -28,19 +28,18 @@
 
 <div id="currentDay">
     <div class="dayDisplay">
-        This will be the current day, this is a place holder
+        
     </div>
     <div class="eventContainer"></div>
     <button id="addEventButton">+</button>
 </div>
 
 <div id="calendarSection">
-    <div class="monthDisplay">
-        <h1>Month</h1>
+    <div class="month-picker-wrapper">
+        <input type="month" id="monthInput">
     </div>
     <div class="calendarDisplay">
 
-    </div>
     </div>
     <br><br>
 </div>


### PR DESCRIPTION
For the practical use of Digiplan, the website needs a calendar which will hide the events from a day when changing to another one. At the moment, the calendar is working by showing the available days and has no info storage property to separate the events. It uses the time.now api to get the information about the days.

First image:
<img width="421" height="642" alt="image" src="https://github.com/user-attachments/assets/10120e08-1bc1-4187-8dd2-0262020e0607" />
This image shows the calendar.

Second image:
<img width="1420" height="236" alt="image" src="https://github.com/user-attachments/assets/e3a2f486-3c90-4bb9-a6b4-959473c4f5cb" />
In this picture, the top date shows the current day, while the date from the bottom shows the selected day from the calendar

Final result:
<img width="1920" height="892" alt="image" src="https://github.com/user-attachments/assets/489cbdcb-ea33-4eb8-8fda-f650407f6fe6" />

Close #16